### PR TITLE
Add `useYarn` flag to `options` to make yarn usage configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ create('create-greet', {
   templateRoot: resolve(__dirname, '..', 'templates'),
   defaultTemplate: 'my-template',
   templatePrefix: 'template-',
+  useYarn: true,
   extra: {
     language: {
       type: 'input',
@@ -215,6 +216,10 @@ create-something <name> --template <template>
 ### defaultTemplate (default: `default`)
 
 Set the default template choice. Works both when `promptForTemplate` is `true` or `false`.
+
+### useYarn (default: `true`)
+
+Prefer `yarn` over `npm`. NPM will still be used if Yarn is not available. 
 
 ### extra (default: `undefined`)
 

--- a/src/index.js
+++ b/src/index.js
@@ -225,8 +225,10 @@ async function create(appName, options) {
 		// do not generate LICENSE
 	}
 
+	const preferYarn = options.useYarn ?? true;
+	const useYarn = preferYarn ? await IsYarnAvailable() : false;
+
 	// install dependencies using yarn / npm
-	const useYarn = await IsYarnAvailable()
 	if (await exists('package.json', projectDir)) {
 		console.log(`Installing dependencies.`)
 		await installDeps(projectDir, useYarn)

--- a/src/index.js
+++ b/src/index.js
@@ -228,12 +228,6 @@ async function create(appName, options) {
 	const preferYarn = options.useYarn ?? true;
 	const useYarn = preferYarn ? await IsYarnAvailable() : false;
 
-	// install dependencies using yarn / npm
-	if (await exists('package.json', projectDir)) {
-		console.log(`Installing dependencies.`)
-		await installDeps(projectDir, useYarn)
-	}
-
 	// init git
 	try {
 		await initGit(projectDir)
@@ -241,6 +235,12 @@ async function create(appName, options) {
 	} catch (err) {
 		if (err.exitCode == 127) return // no git available
 		throw err
+	}
+
+	// install dependencies using yarn / npm
+	if (await exists('package.json', projectDir)) {
+		console.log(`Installing dependencies.`)
+		await installDeps(projectDir, useYarn)
 	}
 
 	const run = (command, options = {}) => {

--- a/templates/template-javascript/src/cli.js
+++ b/templates/template-javascript/src/cli.js
@@ -16,6 +16,7 @@ create('{{kebab name}}', {
   templateRoot,
   defaultTemplate: 'my-template',
   templatePrefix: 'template-',
+  useYarn: true,
   extra: {
     architecture: {
       type: 'list',

--- a/templates/template-typescript/src/cli.ts
+++ b/templates/template-typescript/src/cli.ts
@@ -16,6 +16,7 @@ create('{{kebab name}}', {
   templateRoot,
   defaultTemplate: 'my-template',
   templatePrefix: 'template-',
+  useYarn: true,
   extra: {
     architecture: {
       type: 'list',


### PR DESCRIPTION
Many people do have Yarn installed but still prefer npm or it is preferred by the team/company.
Such an option would make yarn usage configurable by the creator of the intializer.